### PR TITLE
Add Minimum Latency to Trigger Alert

### DIFF
--- a/job.go
+++ b/job.go
@@ -149,7 +149,7 @@ func (j *Job) Run() {
 	j.RecordHistory(ctx, start, finish)
 
 	// Send alert if high latency is detected.
-	if latency > maxLatency {
+	if latency > maxLatency && latency > time.Second {
 		j.manager.alerter.NotifyHighLatency(ctx, j, prev, next, latency, maxLatency)
 	}
 }

--- a/job_test.go
+++ b/job_test.go
@@ -141,7 +141,6 @@ func TestNewJob(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewManager()
 			got := NewJob(manager, tt.args.job, tt.args.waveNumber, tt.args.totalWave)
-			t.Log(got)
 			assert.NotNil(t, got)
 		})
 	}


### PR DESCRIPTION
Only if it's over one second then we should care about it.