### PR TITLE
Add WithAlerter Option

### DIFF
--- a/option.go
+++ b/option.go
@@ -51,3 +51,10 @@ func WithStorage(client storage.Client) Option {
 		m.storage = client
 	}
 }
+
+// WithAlerter determines the alerter used to send notification for high latency job run detected.
+func WithAlerter(client AlerterItf) Option {
+	return func(m *Manager) {
+		m.alerter = client
+	}
+}


### PR DESCRIPTION
It can be used to determine where a notification should be sent.
By default, notification will be sent to a logger.